### PR TITLE
Retry on first-time connection error to the broker

### DIFF
--- a/DahuaVTO.py
+++ b/DahuaVTO.py
@@ -98,7 +98,7 @@ class DahuaVTOClient(asyncio.Protocol):
 
         while not connected:
             try:
-                _LOGGER.info(f"MQTT Broker is trying to connect...")
+                _LOGGER.info("MQTT Broker is trying to connect...")
 
                 self.mqtt_client.connect(self.mqtt_broker_host, int(self.mqtt_broker_port), 60)
                 self.mqtt_client.loop_start()


### PR DESCRIPTION
So, the problem was the first connection to the MQTT Broker.

When the Broker was UP, there was no problem:
```
============Connecting with BROKER UP============
2021-05-02 19:06:48,247 INFO __main__ Connecting
2021-05-02 19:06:48,305 INFO __main__ Initializing MQTT Broker
2021-05-02 19:06:48,306 INFO __main__ MQTT Broker is trying to connect...
2021-05-02 19:06:48,308 INFO __main__ MQTT Broker connected with result code 0
2021-05-02 19:06:48,833 INFO __main__ Attach event manager
===========================================
```

When the Broker was DOWN, the first connection didn't take this in consideration:

```
============Connecting with BROKER DOWN==========

2021-04-27 17:05:50,197 INFO __main__ Connecting
2021-04-27 17:05:50,274 INFO __main__ Connecting MQTT Broker
2021-04-27 17:05:50,275 ERROR __main__ Failed to handle message, error: [Errno 111] Connection refused, Line: 177
===========================================
```
The process would stop here, with no retries until container restart.


Solution:
It'll keep trying until connected with the MQTT broker, just like the on_disconnect handler, but for first-time connection.
```
===========Connecting with BROKER DOWN===========
2021-05-02 19:09:48,751 INFO __main__ Connecting
2021-05-02 19:09:48,799 INFO __main__ Initializing MQTT Broker,
2021-05-02 19:09:48,799 INFO __main__ MQTT Broker is trying to connect...,
2021-05-02 19:09:48,800 ERROR __main__ Failed to connect to broker, retry in 60 seconds, error: [Errno 111] Connection refused, Line: 103,

2021-05-02 19:10:48,860 INFO __main__ MQTT Broker is trying to connect...,
2021-05-02 19:10:48,861 ERROR __main__ Failed to connect to broker, retry in 60 seconds, error: [Errno 111] Connection refused, Line: 103

2021-05-02 19:11:48,919 INFO __main__ MQTT Broker is trying to connect...
2021-05-02 19:11:48,959 INFO __main__ Attach event manager,
2021-05-02 19:11:49,125 INFO __main__ MQTT Broker connected with result code 0,
===========================================
```

I also tested a [solution mentioned in the PAHO lib for this problem](https://github.com/eclipse/paho.mqtt.python/issues/457), with websocket type connection but it didn't work...

